### PR TITLE
Add BBR congestion control configuration to TCP Tweaker script

### DIFF
--- a/TCP-Tweaker
+++ b/TCP-Tweaker
@@ -2,56 +2,60 @@
 tput setaf 7 ; tput setab 4 ; tput bold ; printf '%35s%s%-20s\n' "TCP Tweaker 1.0" ; tput sgr0
 if [[ `grep -c "^#PH56" /etc/sysctl.conf` -eq 1 ]]
 then
-	echo ""
-	echo "TCP Tweaker network settings have already been added to the system!"
-	echo ""
-	read -p "Do you want to remove TCP Tweaker settings? [y/n]: " -e -i n resposta0
-	if [[ "$resposta0" = 'y' ]]; then
-		grep -v "^#PH56
+    echo ""
+    echo "TCP Tweaker network settings have already been added to the system!"
+    echo ""
+    read -p "Do you want to remove TCP Tweaker settings? [y/n]: " -e -i n resposta0
+    if [[ "$resposta0" = 'y' ]]; then
+        grep -v "^#PH56
 net.ipv4.tcp_window_scaling = 1
 net.core.rmem_max = 16777216
 net.core.wmem_max = 16777216
 net.ipv4.tcp_rmem = 4096 87380 16777216
 net.ipv4.tcp_wmem = 4096 16384 16777216
 net.ipv4.tcp_low_latency = 1
-net.ipv4.tcp_slow_start_after_idle = 0" /etc/sysctl.conf > /tmp/syscl && mv /tmp/syscl /etc/sysctl.conf
+net.ipv4.tcp_slow_start_after_idle = 0
+net.core.default_qdisc = fq
+net.ipv4.tcp_congestion_control = bbr" /etc/sysctl.conf > /tmp/syscl && mv /tmp/syscl /etc/sysctl.conf
 sysctl -p /etc/sysctl.conf > /dev/null
-		echo ""
-		echo "TCP Tweaker network settings were successfully removed."
-		echo ""
-	exit
-	else 
-		echo ""
-		exit
-	fi
+        echo ""
+        echo "TCP Tweaker network settings were successfully removed."
+        echo ""
+    exit
+    else 
+        echo ""
+        exit
+    fi
 else
-	echo ""
-	echo "This is an experimental script. Use at your own risk!"
-	echo "This script will change some network settings"
-	echo "to reduce latency and improve speed."
-	echo ""
-	read -p "Proceed with installation? [y/n]: " -e -i n resposta
-	if [[ "$resposta" = 'y' ]]; then
-	echo ""
-	echo "Modifying the following settings:"
-	echo " " >> /etc/sysctl.conf
-	echo "#PH56" >> /etc/sysctl.conf
-echo "net.ipv4.tcp_window_scaling = 1
+    echo ""
+    echo "This is an experimental script. Use at your own risk!"
+    echo "This script will change some network settings"
+    echo "to reduce latency and improve speed."
+    echo ""
+    read -p "Proceed with installation? [y/n]: " -e -i n resposta
+    if [[ "$resposta" = 'y' ]]; then
+    echo ""
+    echo "Modifying the following settings:"
+    echo " " >> /etc/sysctl.conf
+    echo "#PH56" >> /etc/sysctl.conf
+    echo "net.ipv4.tcp_window_scaling = 1
 net.core.rmem_max = 16777216
 net.core.wmem_max = 16777216
 net.ipv4.tcp_rmem = 4096 87380 16777216
 net.ipv4.tcp_wmem = 4096 16384 16777216
 net.ipv4.tcp_low_latency = 1
-net.ipv4.tcp_slow_start_after_idle = 0" >> /etc/sysctl.conf
-echo ""
-sysctl -p /etc/sysctl.conf
-		echo ""
-		echo "TCP Tweaker network settings have been added successfully."
-		echo ""
-	else
-		echo ""
-		echo "Installation was canceled by the user!"
-		echo ""
-	fi
+net.ipv4.tcp_slow_start_after_idle = 0
+net.core.default_qdisc = fq
+net.ipv4.tcp_congestion_control = bbr" >> /etc/sysctl.conf
+    echo ""
+    sysctl -p /etc/sysctl.conf
+        echo ""
+        echo "TCP Tweaker network settings have been added successfully."
+        echo ""
+    else
+        echo ""
+        echo "Installation was canceled by the user!"
+        echo ""
+    fi
 fi
 exit


### PR DESCRIPTION
 This commit adds the BBR (Bottleneck Bandwidth and RTT) congestion control configuration to the existing TCP Tweaker script. The BBR configuration includes setting net.core.default_qdisc to fq and net.ipv4.tcp_congestion_control to bbr in the /etc/sysctl.conf file. This enables BBR as the congestion control algorithm, which can improve network latency and speed. Please note that the changes should be applied with caution and tested in a controlled environment.