### PR TITLE
Add reset time to panel users list

### DIFF
--- a/Web Panel/app/app/Http/Controllers/UserController.php
+++ b/Web Panel/app/app/Http/Controllers/UserController.php
@@ -255,7 +255,27 @@ class UserController extends Controller
         }
         return redirect()->back()->with('success', 'Reset Traffic');
     }
-
+	public function reset_time(Request $request,$username)
+    {
+        if (!is_string($username)) {
+            abort(400, 'Not Valid Username');
+        }
+        $user = Auth::user();
+        if($user->permission=='admin') {
+            $check_user = Users::where('username',$username)->count();
+            if ($check_user > 0) {
+                Users::where('username', $username)->update(['start_date' => '', 'end_date' => '']);
+            }
+        }
+        else
+        {
+            $check_user = Users::where('username', $username)->where('customer_user', $user->username)->count();
+            if ($check_user > 0) {
+                Users::where('username', $username)->update(['start_date' => '', 'end_date' => '']);
+            }
+        }
+        return redirect()->back()->with('success', 'Reset Time');
+    }
     public function delete(Request $request,$username)
     {
         if (!is_string($username)) {
@@ -290,7 +310,6 @@ class UserController extends Controller
     }
     public function delete_bulk(Request $request)
     {
-
         $user = Auth::user();
         if ($user->permission == 'admin') {
             foreach ($request->usernamed as $username) {

--- a/Web Panel/app/resources/views/users/home.blade.php
+++ b/Web Panel/app/resources/views/users/home.blade.php
@@ -171,6 +171,8 @@
                                                                    href="{{ route('user.deactive', ['username' => $user->username]) }}">Deactive</a>
                                                                 <a class="dropdown-item"
                                                                    href="{{ route('user.reset', ['username' => $user->username]) }}">Reset Traffic</a>
+																<a class="dropdown-item"
+                                                                   href="{{ route('user.resettime', ['username' => $user->username]) }}">Reset Time</a>
                                                                 <a class="dropdown-item"
                                                                    href="{{ route('user.delete', ['username' => $user->username]) }}">Delete</a>
                                                             </div>

--- a/Web Panel/app/routes/web.php
+++ b/Web Panel/app/routes/web.php
@@ -31,6 +31,7 @@ Route::prefix('cp')->group(function()
     Route::get('/user/active/{username}',[UserController::class,'activeuser'])->name('user.active');
     Route::get('/user/deactive/{username}',[UserController::class,'deactiveuser'])->name('user.deactive');
     Route::get('/user/reset/{username}',[UserController::class,'reset_traffic'])->name('user.reset');
+	Route::get('/user/resettime/{username}',[UserController::class,'reset_time'])->name('user.resettime');
     Route::get('/user/delete/{username}',[UserController::class,'delete'])->name('user.delete');
     Route::post('/user/delete/bulk',[UserController::class,'delete_bulk'])->name('user.delete.bulk');
     Route::post('/user/renewal',[UserController::class,'renewal'])->name('new.renewal');


### PR DESCRIPTION
Add "reset time" feature to the panel's user list.
When you test a user, their period begins. With this feature, you can reset their datetime.